### PR TITLE
Improve performance of "## no extract maketext" processing.

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,7 @@ Revision history for Text-Extract-MaketextCallPhrases
     - Add support for optional matches
     - bump req ver of M::W to latest
     - Add support for getting matches in arguments besides the first
+    - Improve performance of "## no extract maketext" processing.
 
 0.92  2013-10-22 12:09:33
     - add more RELEASE_TESTING tests

--- a/lib/Text/Extract/MaketextCallPhrases.pm
+++ b/lib/Text/Extract/MaketextCallPhrases.pm
@@ -58,22 +58,15 @@ sub get_phrases_in_text {
         my $rx_conf_hr = defined $regexp->[2] && ref( $regexp->[2] ) eq 'HASH' ? $regexp->[2] : { 'optional' => 0, 'arg_position' => 0 };
         $rx_conf_hr->{arg_position} = exists $rx_conf_hr->{arg_position} ? int( abs( $rx_conf_hr->{arg_position} ) ) : 0;    # if caller passes a non-numeric value this should warn, that is a feature!
 
-        while ( defined $text_working_copy && $text_working_copy =~ m/($regexp->[0]|## no extract maketext)/ ) {
-            my $matched = $1;
+        $text_working_copy =~ s{^.*## no extract maketext.*$}{}gm;
 
-            # we have a (possibly multiline) chunk w/ notation-not-preceeded-by-token that we should ignore
-            if ( $matched eq '## no extract maketext' ) {
-                $text_working_copy =~ s/.*## no extract maketext[^\n]*//;
-                next;
-            }
+        while ( defined $text_working_copy && $text_working_copy =~ m/($regexp->[0])/ ) {
+            my $matched = $1;
 
             my $pre;
 
             # TODO: incorporate the \s* into results: 'post_token_ws' => $1 || '' ?
             ( $pre, $text_working_copy ) = split( m/$regexp->[0]\s*/, $text_working_copy, 2 );    # the \s* takes into account trailing WS that Text::Balanced ignores which then can throw off the offset
-
-            # we have a token line that we should ignore
-            next if $text_working_copy =~ s/^[^\n]*## no extract maketext[^\n]*//;
 
             my $offset = $original_len - length($text_working_copy);
 


### PR DESCRIPTION
Instead of iteratively stripping out "## no extract maketext" lines,
which causes two regular expression matches on an entire file per
iteration, remove all in a single pass.

In a heavy use of this module across many files, this has been shown to
reduce the time to build a single locale database to roughly 21% of what
it used to be, while still producing identical results.

cPanel case for reference: 104873
