### PR TITLE
Add support for .translatable() marker functions

### DIFF
--- a/lib/Text/Extract/MaketextCallPhrases.pm
+++ b/lib/Text/Extract/MaketextCallPhrases.pm
@@ -3,7 +3,7 @@ package Text::Extract::MaketextCallPhrases;
 use strict;
 use warnings;
 
-$Text::Extract::MaketextCallPhrases::VERSION = '0.92';
+$Text::Extract::MaketextCallPhrases::VERSION = '0.93';
 
 use Text::Balanced      ();
 use String::Unquotemeta ();
@@ -19,7 +19,7 @@ sub import {
 }
 
 my $default_regexp_conf_item = [
-    qr/(?:(?:^|\:|\s|=|\()translatable|(?:make|lex)text(?:_[a-zA-Z0-9_]+_context)?)\s*\(?/,
+    qr/(?:(?:^|\:|\s|=|\(|\.)translatable|(?:make|lex)text(?:_[a-zA-Z0-9_]+_context)?)\s*\(?/,
     sub { return substr( $_[0], -1, 1 ) eq '(' ? qr/\s*\)/ : qr/\s*\;/ },
 ];
 
@@ -408,7 +408,7 @@ Text::Extract::MaketextCallPhrases - Extract phrases from maketext–call–look
 
 =head1 VERSION
 
-This document describes Text::Extract::MaketextCallPhrases version 0.92
+This document describes Text::Extract::MaketextCallPhrases version 0.93
 
 =head1 SYNOPSIS
 

--- a/t/04.default_regex_non_maketext.t
+++ b/t/04.default_regex_non_maketext.t
@@ -1,4 +1,4 @@
-use Test::More tests => 33 + ( 3 * 5 );
+use Test::More tests => 35 + ( 3 * 5 );
 
 use Text::Extract::MaketextCallPhrases;
 
@@ -117,3 +117,13 @@ is( $results->[27]->{'phrase'}, 'I am method!',     "C E ->create" );
 is( $results->[28]->{'phrase'}, 'foo I am method!', "C E with one more NS chunk ->create" );
 is( $results->[29]->{'phrase'}, 'bar I am method!', "C E with two more NS chunks ->create" );
 is( $results->[30]->{'phrase'}, 'baz I am method!', "C E with three more NS chunks ->create" );
+
+
+$blob = <<'END_EXAMP_2';
+object.translatable("Herp a Derp");
+object.translatable("Herp a Derp with substitution: [_1]");
+END_EXAMP_2
+
+$results = get_phrases_in_text($blob);
+is( $results->[0]->{'phrase'}, "Herp a Derp",                         ".translatable() aka JavaScript" );
+is( $results->[1]->{'phrase'}, "Herp a Derp with substitution: [_1]", ".translatable() aka JavaScript with a parameter" );


### PR DESCRIPTION
This is meant to address Issue#3.

This supports languages like JavaScript where it would not be a good idea to
implement translatable() as a global since it is common to have global
collisions. So an implementation like this:

Locale.Maketext.Utils.MarkPhrase.translatable = function(str) {
    return str;
};

Could be used to harvest phrases from JavaScript like:

var defaultKey = Locale.Maketext.Utils.MarkPhrase.translatable("You have [_1] of [_2] items selected.");
var key = userOverride || defaultKey;
var localized = LOCALE.maketext(key);
