### PR TITLE
fix warnings when updating text_working_copy

### DIFF
--- a/lib/Text/Extract/MaketextCallPhrases.pm
+++ b/lib/Text/Extract/MaketextCallPhrases.pm
@@ -157,6 +157,7 @@ sub get_phrases_in_text {
                     if ( !defined $phrase ) {
                         ( $phrase, $text_working_copy ) = Text::Balanced::extract_quotelike($text_working_copy);
                     }
+                    $text_working_copy = '' unless defined $text_working_copy;
                 }
             }
 

--- a/t/05.no_extract_maketext.t
+++ b/t/05.no_extract_maketext.t
@@ -71,7 +71,7 @@ sub _str_with_double_notation {
 sub _str_with_notation {
     my $str = _str_without_notation();
 
-    $str =~ s/(sub maketext {)/$1 ## no extract maketext/;
+    $str =~ s/(sub maketext \{)/$1 ## no extract maketext/;
     $str =~ s/(maketext foo.*)/$1 ## no extract maketext/;
     $str =~ s/(odd maketext\()/$1 ## no extract maketext/;
 


### PR DESCRIPTION
This is providing a fix for GH #17

When running internal tool cplint notice several warnings coming from 
```
### warnings
Use of uninitialized value $text_working_copy in substitution (s///) at /usr/local/cpanel/3rdparty/perl/526/lib64/perl5/cpanel_lib/Text/Extract/MaketextCallPhrases.pm line 149, <$fh> line 287.
Use of uninitialized value in subtraction (-) at /usr/local/cpanel/3rdparty/perl/526/lib64/perl5/cpanel_lib/Text/Extract/MaketextCallPhrases.pm line 151, <$fh> line 287.
Use of uninitialized value $text_working_copy in substitution (s///) at /usr/local/cpanel/3rdparty/perl/526/lib64/perl5/cpanel_lib/Text/Extract/MaketextCallPhrases.pm line 149, <$fh> line 287.
Use of uninitialized value in subtraction (-) at /usr/local/cpanel/3rdparty/perl/526/lib64/perl5/cpanel_lib/Text/Extract/MaketextCallPhrases.pm line 151, <$fh> line 287.
```